### PR TITLE
Schedule injection, duration override, and small fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
-    "format": "prettier --write ."
+    "prettier:format": "prettier --write .",
+    "prettier:check": "prettier --check ."
   },
   "devDependencies": {
     "@iconify/json": "^2.2.245",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,9 +5,7 @@ import { dev } from '$app/environment';
 // generating a noisy SvelteKitError 404 in the terminal. Short-circuit
 // it with a 204 so the dev log stays clean. Production never sees the
 // probe; gating on `dev` makes the intent explicit.
-const SUPPRESSED_DEV_PATHS = new Set([
-  '/.well-known/appspecific/com.chrome.devtools.json',
-]);
+const SUPPRESSED_DEV_PATHS = new Set(['/.well-known/appspecific/com.chrome.devtools.json']);
 
 export const handle: Handle = async ({ event, resolve }) => {
   if (dev && SUPPRESSED_DEV_PATHS.has(event.url.pathname)) {

--- a/src/lib/client/api.ts
+++ b/src/lib/client/api.ts
@@ -173,7 +173,10 @@ export function poll(updated: (data: Data) => void) {
 
     const apiData = transformRoutes(routes, state.timestamp);
 
-    if (!history) history = loadHistory();
+    // Reload from disk each tick so page-level writes (eviction,
+    // reconciliation) aren't clobbered by our in-memory snapshot. JSON parse
+    // is cheap relative to the network fetch we just did.
+    history = loadHistory();
     history = pruneHistory(history, apiData.timestamp);
     history = upsertFromApi(history, apiData, apiData.timestamp);
     saveHistory(history);

--- a/src/lib/client/history.ts
+++ b/src/lib/client/history.ts
@@ -1,6 +1,10 @@
 import { isDev } from '$lib/env';
 import { vessels } from '$lib/data/vessels';
 
+import {
+  findPreviousSailingsFromScrape,
+  type PrevSailingScrapeSource,
+} from './schedule';
 import type { Data, PreviousSailing, Route, Sailing, SailingStatus, Vessel } from './types';
 
 const STORAGE_VERSION = 1;
@@ -213,6 +217,22 @@ export function upsertFromApi(state: HistoryState, data: Data, now: Date): Histo
       if (!(sailing.depart instanceof Date)) continue;
 
       const match = findMatch(rows, route.id, sailing.depart, claimed);
+
+      // Only upsert from sailings that haven't departed yet. Once a sailing
+      // is current/past, scrapemyferry's currentConditionsBeta has more
+      // accurate actuals (departed/arrived/vessel) than the BC Ferries JSON
+      // API, and persisting the API's values to localStorage was
+      // contaminating the previousSailings lookup. We still bump lastSeenAt
+      // on existing rows so they don't get pruned out from under us during
+      // the 24h window.
+      if (sailing.status !== 'future') {
+        if (match) {
+          claimed.add(match.scheduledDepart);
+          match.lastSeenAt = nowIso;
+        }
+        continue;
+      }
+
       const departIso = sailing.depart.toISOString();
       const arriveIso = sailing.arrive instanceof Date ? sailing.arrive.toISOString() : undefined;
 
@@ -316,39 +336,63 @@ export function attachPreviousSailings<T extends Sailing>(
 }
 
 /**
- * Re-runs attachPreviousSailings across every sailing in the route. Idempotent
- * for sailings that mergeWithHistory already enriched (live API sailings), so
- * the cost is just lookup work. Needed because injectMissingSailings creates
- * synthesized sailings AFTER mergeWithHistory has run — without this pass
- * those sailings never get their previousSailings attached.
+ * Attach previousSailings to every sailing in the route, preferring
+ * scrapemyferry's authoritative arrivedUnderway data over localStorage
+ * history. localStorage is only consulted as a fallback for vessels that
+ * scrape data doesn't cover (e.g. a vessel that briefly served a route
+ * outside the current page's scope).
  */
 export function attachPreviousSailingsToRoute(
   route: Route | undefined,
   routes: Map<string, Route> | undefined,
+  scrapeSources?: PrevSailingScrapeSource[],
   scheduledListByRoute?: Map<string, Date[]>,
 ): Route | undefined {
   if (!route || !routes) return route;
-  if (typeof localStorage === 'undefined') return route;
-  const state = loadHistory();
-  if (state.sailings.length === 0) return route;
+
+  const hasScrape = !!scrapeSources?.length;
+  const hasLocalStorage = typeof localStorage !== 'undefined';
+  const state = hasLocalStorage ? loadHistory() : undefined;
+  const hasFallback = !!state && state.sailings.length > 0;
+  if (!hasScrape && !hasFallback) return route;
 
   const sailings = route.sailings.map((sailing) => {
-    const enhanced = attachPreviousSailings(sailing, state, routes);
-    if (!enhanced.previousSailings || !scheduledListByRoute?.size) return enhanced;
-    // Override each previous sailing's scheduledDepart with the closest
-    // dailySchedule entry for ITS route (forward or reverse). Stored
-    // scheduledDepart is often contaminated by the API's windowed observation
-    // pattern — if we caught the sailing while a different one with a nearby
-    // scheduled time was the only match candidate, findMatch glued the rows
-    // together and the wrong scheduledDepart stuck.
-    const previousSailings = enhanced.previousSailings.map((prev) => {
-      const scheduledList = scheduledListByRoute.get(prev.routeCode);
-      if (!scheduledList?.length) return prev;
-      const closest = findClosestScheduled(prev.depart, scheduledList);
-      if (!closest) return prev;
-      return { ...prev, scheduledDepart: closest };
-    });
-    return { ...enhanced, previousSailings };
+    const vesselName = sailing.vessel?.name;
+    if (!vesselName) return sailing;
+    if (!(sailing.depart instanceof Date)) return sailing;
+
+    let previousSailings: PreviousSailing[] = [];
+    if (hasScrape) {
+      previousSailings = findPreviousSailingsFromScrape(
+        vesselName,
+        sailing.depart.getTime(),
+        scrapeSources!,
+      );
+    }
+
+    // Fallback to localStorage only when scrape gave us nothing.
+    if (previousSailings.length === 0 && hasFallback) {
+      previousSailings = findPreviousVesselSailings(
+        state!.sailings,
+        vesselName,
+        sailing.depart.getTime(),
+        routes,
+      );
+      // For fallback rows, override scheduledDepart from authoritative
+      // dailySchedule when available — stored value may be contaminated.
+      if (previousSailings.length > 0 && scheduledListByRoute?.size) {
+        previousSailings = previousSailings.map((prev) => {
+          const scheduledList = scheduledListByRoute.get(prev.routeCode);
+          if (!scheduledList?.length) return prev;
+          const closest = findClosestScheduled(prev.depart, scheduledList);
+          if (!closest) return prev;
+          return { ...prev, scheduledDepart: closest };
+        });
+      }
+    }
+
+    if (previousSailings.length === 0) return sailing;
+    return { ...sailing, previousSailings };
   });
   return { ...route, sailings };
 }
@@ -376,15 +420,17 @@ export function mergeWithHistory(state: HistoryState, data: Data, now: Date): Da
 
   for (const [id, route] of data.routes) {
     const matchedScheduled = new Set<string>();
+    // mergeWithHistory only handles scheduledDepart enrichment + transitional
+    // 'departing' injection. previousSailings attachment is deferred to a
+    // page-level pass (attachPreviousSailingsToRoute) so it can prefer
+    // scrapemyferry's authoritative arrivedUnderway data over the
+    // localStorage history.
     const enhanced = route.sailings.map((sailing) => {
       if (!(sailing.depart instanceof Date)) return sailing;
       const match = findMatch(state.sailings, route.id, sailing.depart, matchedScheduled);
-      let next: Sailing = sailing;
-      if (match) {
-        matchedScheduled.add(match.scheduledDepart);
-        next = { ...next, scheduledDepart: parseStoredDate(match.scheduledDepart) };
-      }
-      return attachPreviousSailings(next, state, data.routes);
+      if (!match) return sailing;
+      matchedScheduled.add(match.scheduledDepart);
+      return { ...sailing, scheduledDepart: parseStoredDate(match.scheduledDepart) };
     });
 
     const injected: Sailing[] = [];
@@ -405,19 +451,13 @@ export function mergeWithHistory(state: HistoryState, data: Data, now: Date): Da
         ? { ...vessels[stored.vesselName], name: stored.vesselName }
         : undefined;
 
-      injected.push(
-        attachPreviousSailings(
-          {
-            depart: parseStoredDate(stored.latestDepart),
-            arrive: stored.latestArrive ? parseStoredDate(stored.latestArrive) : undefined,
-            scheduledDepart: parseStoredDate(stored.scheduledDepart),
-            vessel,
-            status: 'departing',
-          },
-          state,
-          data.routes,
-        ),
-      );
+      injected.push({
+        depart: parseStoredDate(stored.latestDepart),
+        arrive: stored.latestArrive ? parseStoredDate(stored.latestArrive) : undefined,
+        scheduledDepart: parseStoredDate(stored.scheduledDepart),
+        vessel,
+        status: 'departing',
+      });
     }
 
     const sailings =

--- a/src/lib/client/history.ts
+++ b/src/lib/client/history.ts
@@ -90,6 +90,49 @@ function parseStoredDate(iso: string): Date {
   return d;
 }
 
+/**
+ * Drop stored rows whose scheduledDepart doesn't match any actual entry in
+ * the authoritative dailySchedule for their route. These are usually
+ * "phantom" rows caused by findMatch latching onto the wrong scheduled slot
+ * during a windowed API observation, and leaving them in place means the
+ * NEXT findMatch can latch onto them too, propagating the contamination.
+ *
+ * Limited to routes we actually have dailySchedule for (forward + reverse);
+ * rows on routes we can't verify are left alone.
+ */
+export function evictContaminatedRows(
+  state: HistoryState,
+  knownSchedules: Map<string, Date[]>,
+  matchWindowMs: number = 5 * 60 * 1000,
+): HistoryState {
+  if (knownSchedules.size === 0) return state;
+  let mutated = false;
+
+  const keep = state.sailings.filter((row) => {
+    const schedule = knownSchedules.get(row.routeCode);
+    if (!schedule?.length) return true;
+
+    const scheduledMs = Date.parse(row.scheduledDepart);
+    if (!Number.isFinite(scheduledMs)) {
+      mutated = true;
+      return false;
+    }
+
+    const hasMatch = schedule.some(
+      (s) => Math.abs(s.getTime() - scheduledMs) <= matchWindowMs,
+    );
+    if (!hasMatch) mutated = true;
+    return hasMatch;
+  });
+
+  if (!mutated) return state;
+  return {
+    version: STORAGE_VERSION,
+    updatedAt: new Date().toISOString(),
+    sailings: keep,
+  };
+}
+
 export interface ScheduledDepartCorrection {
   /** matches stored row.latestDepart (which always equals the live sailing's
    *  depart after the most recent upsertFromApi pass) */

--- a/src/lib/client/history.ts
+++ b/src/lib/client/history.ts
@@ -243,10 +243,7 @@ export function upsertFromApi(state: HistoryState, data: Data, now: Date): Histo
   return { version: STORAGE_VERSION, updatedAt: nowIso, sailings: rows };
 }
 
-function buildPreviousSailing(
-  row: StoredSailing,
-  routes: Map<string, Route>,
-): PreviousSailing {
+function buildPreviousSailing(row: StoredSailing, routes: Map<string, Route>): PreviousSailing {
   const route = routes.get(row.routeCode);
   // routeCode is from+to concatenated (e.g. "HSBLNG"); fall back to splitting
   // it if the route isn't currently in the API payload (vessel briefly served

--- a/src/lib/client/history.ts
+++ b/src/lib/client/history.ts
@@ -255,13 +255,22 @@ function buildPreviousSailing(row: StoredSailing, routes: Map<string, Route>): P
     ? { ...vessels[row.vesselName], name: row.vesselName }
     : undefined;
 
+  const depart = parseStoredDate(row.latestDepart);
+  const actualArrive = row.latestArrive ? parseStoredDate(row.latestArrive) : undefined;
+  // Project arrival from depart + scheduled duration when the API never
+  // reported an actual arrival. Carries the departure delay forward into the
+  // arrival delta, which is the best signal we have for "how late did this
+  // inbound trip actually run". Skipped when duration is 0 because the
+  // projection would degenerate to arrive = depart and produce noisy badges.
+  const arrive = actualArrive ?? (duration > 0 ? new Date(depart.getTime() + duration * 1000) : undefined);
+
   return {
     routeCode: row.routeCode,
     from,
     to,
     duration,
-    depart: parseStoredDate(row.latestDepart),
-    arrive: row.latestArrive ? parseStoredDate(row.latestArrive) : undefined,
+    depart,
+    arrive,
     scheduledDepart: parseStoredDate(row.scheduledDepart),
     vessel,
     status: row.lastStatus,
@@ -316,14 +325,47 @@ export function attachPreviousSailings<T extends Sailing>(
 export function attachPreviousSailingsToRoute(
   route: Route | undefined,
   routes: Map<string, Route> | undefined,
+  scheduledListByRoute?: Map<string, Date[]>,
 ): Route | undefined {
   if (!route || !routes) return route;
   if (typeof localStorage === 'undefined') return route;
   const state = loadHistory();
   if (state.sailings.length === 0) return route;
 
-  const sailings = route.sailings.map((sailing) => attachPreviousSailings(sailing, state, routes));
+  const sailings = route.sailings.map((sailing) => {
+    const enhanced = attachPreviousSailings(sailing, state, routes);
+    if (!enhanced.previousSailings || !scheduledListByRoute?.size) return enhanced;
+    // Override each previous sailing's scheduledDepart with the closest
+    // dailySchedule entry for ITS route (forward or reverse). Stored
+    // scheduledDepart is often contaminated by the API's windowed observation
+    // pattern — if we caught the sailing while a different one with a nearby
+    // scheduled time was the only match candidate, findMatch glued the rows
+    // together and the wrong scheduledDepart stuck.
+    const previousSailings = enhanced.previousSailings.map((prev) => {
+      const scheduledList = scheduledListByRoute.get(prev.routeCode);
+      if (!scheduledList?.length) return prev;
+      const closest = findClosestScheduled(prev.depart, scheduledList);
+      if (!closest) return prev;
+      return { ...prev, scheduledDepart: closest };
+    });
+    return { ...enhanced, previousSailings };
+  });
   return { ...route, sailings };
+}
+
+function findClosestScheduled(depart: Date, scheduledList: Date[]): Date | undefined {
+  const departMs = depart.getTime();
+  let best: Date | undefined;
+  let bestDelta = Infinity;
+  for (const s of scheduledList) {
+    const delta = Math.abs(s.getTime() - departMs);
+    if (delta > 60 * 60 * 1000) continue;
+    if (delta < bestDelta) {
+      bestDelta = delta;
+      best = s;
+    }
+  }
+  return best;
 }
 
 export function mergeWithHistory(state: HistoryState, data: Data, now: Date): Data {

--- a/src/lib/client/history.ts
+++ b/src/lib/client/history.ts
@@ -288,7 +288,7 @@ function findPreviousVesselSailings(
     .map((row) => buildPreviousSailing(row, routes));
 }
 
-function attachPreviousSailings<T extends Sailing>(
+export function attachPreviousSailings<T extends Sailing>(
   sailing: T,
   state: HistoryState,
   routes: Map<string, Route>,
@@ -304,6 +304,26 @@ function attachPreviousSailings<T extends Sailing>(
   );
   if (previousSailings.length === 0) return sailing;
   return { ...sailing, previousSailings };
+}
+
+/**
+ * Re-runs attachPreviousSailings across every sailing in the route. Idempotent
+ * for sailings that mergeWithHistory already enriched (live API sailings), so
+ * the cost is just lookup work. Needed because injectMissingSailings creates
+ * synthesized sailings AFTER mergeWithHistory has run — without this pass
+ * those sailings never get their previousSailings attached.
+ */
+export function attachPreviousSailingsToRoute(
+  route: Route | undefined,
+  routes: Map<string, Route> | undefined,
+): Route | undefined {
+  if (!route || !routes) return route;
+  if (typeof localStorage === 'undefined') return route;
+  const state = loadHistory();
+  if (state.sailings.length === 0) return route;
+
+  const sailings = route.sailings.map((sailing) => attachPreviousSailings(sailing, state, routes));
+  return { ...route, sailings };
 }
 
 export function mergeWithHistory(state: HistoryState, data: Data, now: Date): Data {

--- a/src/lib/client/schedule.ts
+++ b/src/lib/client/schedule.ts
@@ -44,6 +44,32 @@ function parseScheduleDurationSeconds(value: string): number {
   return parseInt(match[1]) * 3600 + parseInt(match[2]) * 60;
 }
 
+/**
+ * Construct a routes Map with duration overrides applied for both the current
+ * (forward) route and its reverse leg, using each direction's own dailySchedule.
+ * This is what attachPreviousSailingsToRoute needs in order to compute correct
+ * duration-dependent badges (totalDelay, projected arrive) for prior sailings
+ * on either direction.
+ */
+export function buildEnrichedRoutes(
+  routes: Map<string, Route> | undefined,
+  selectedRoute: Route | undefined,
+  reverseDailySchedule: DailySchedule | null | undefined,
+): Map<string, Route> | undefined {
+  if (!routes) return routes;
+  const map = new Map(routes);
+  if (selectedRoute) {
+    map.set(selectedRoute.id, selectedRoute);
+    const reverseId = `${selectedRoute.to}${selectedRoute.from}`;
+    const reverse = map.get(reverseId);
+    if (reverse) {
+      const enriched = applyDurationOverride(reverse, reverseDailySchedule);
+      if (enriched) map.set(reverseId, enriched);
+    }
+  }
+  return map;
+}
+
 export function buildScheduledList(dailySchedule: DailySchedule | null | undefined): Date[] {
   if (!dailySchedule?.sailings?.length) return [];
   return dailySchedule.sailings

--- a/src/lib/client/schedule.ts
+++ b/src/lib/client/schedule.ts
@@ -7,7 +7,10 @@ import {
   saveHistory,
   type ScheduledDepartCorrection,
 } from './history';
-import type { Route, Sailing, SailingStatus, Vessel } from './types';
+import type { PreviousSailing, Route, Sailing, SailingStatus, Vessel } from './types';
+
+const PREVIOUS_SAILING_WINDOW_MS = 6 * 60 * 60 * 1000;
+const PREVIOUS_SAILING_LIMIT = 2;
 
 const MATCH_WINDOW_MS = 60 * 60 * 1000;
 
@@ -212,6 +215,83 @@ function sortMs(s: Sailing): number {
   if (s.scheduledDepart instanceof Date) return s.scheduledDepart.getTime();
   if (s.depart instanceof Date) return s.depart.getTime();
   return Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * Source of scrapemyferry "what happened today" data for one route direction,
+ * used to build PreviousSailing rows for an inbound vessel.
+ */
+export interface PrevSailingScrapeSource {
+  routeCode: string;
+  from: string;
+  to: string;
+  duration: number;
+  conditions: CurrentConditionsBeta | null | undefined;
+  dailySchedule: DailySchedule | null | undefined;
+}
+
+/**
+ * Build previousSailings for `vesselName` from scrapemyferry's authoritative
+ * arrivedUnderway data, drawing from both the forward and reverse route
+ * sources passed in. This is the primary path — localStorage history is only
+ * consulted as a fallback when scrape data has no entries for the vessel
+ * (e.g. it served a route outside our current page's scope).
+ */
+export function findPreviousSailingsFromScrape(
+  vesselName: string,
+  beforeMs: number,
+  sources: PrevSailingScrapeSource[],
+): PreviousSailing[] {
+  const cutoffMs = beforeMs - PREVIOUS_SAILING_WINDOW_MS;
+  type Candidate = { prev: PreviousSailing; departMs: number };
+  const candidates: Candidate[] = [];
+
+  for (const src of sources) {
+    const arrivedUnderway = src.conditions?.arrivedUnderway;
+    if (!arrivedUnderway?.length) continue;
+
+    // Per-sailing duration from dailySchedule, keyed by the scheduled time
+    // string used in arrivedUnderway entries.
+    const durationByScheduled = new Map<string, number>();
+    for (const entry of src.dailySchedule?.sailings ?? []) {
+      const dur = parseScheduleDurationSeconds(entry.duration);
+      if (dur > 0) durationByScheduled.set(entry.depart, dur);
+    }
+
+    for (const entry of arrivedUnderway) {
+      if (entry.vessel?.name !== vesselName) continue;
+      const departed = parseWallClockTime(entry.departed);
+      if (!departed) continue;
+      const departMs = departed.getTime();
+      if (departMs >= beforeMs || departMs < cutoffMs) continue;
+
+      const scheduled = parseWallClockTime(entry.scheduled);
+      const arrived = entry.arrived ? parseWallClockTime(entry.arrived) : undefined;
+      const duration = durationByScheduled.get(entry.scheduled) ?? src.duration;
+      // Project arrive from depart + scheduled duration when the API hasn't
+      // recorded an actual arrival yet (vessel still underway).
+      const arrive =
+        arrived ?? (duration > 0 ? new Date(departMs + duration * 1000) : undefined);
+
+      candidates.push({
+        prev: {
+          routeCode: src.routeCode,
+          from: src.from,
+          to: src.to,
+          duration,
+          depart: departed,
+          arrive,
+          scheduledDepart: scheduled,
+          vessel: makeVessel(vesselName),
+          status: 'past',
+        },
+        departMs,
+      });
+    }
+  }
+
+  candidates.sort((a, b) => b.departMs - a.departMs);
+  return candidates.slice(0, PREVIOUS_SAILING_LIMIT).map((c) => c.prev);
 }
 
 /**

--- a/src/lib/client/schedule.ts
+++ b/src/lib/client/schedule.ts
@@ -2,6 +2,7 @@ import type { CurrentConditionsBeta, DailySchedule } from 'scrapemyferry';
 import { vessels } from '$lib/data/vessels';
 import { parseWallClockTime } from '$lib/utils';
 import {
+  evictContaminatedRows,
   loadHistory,
   reconcileScheduledDepartures,
   saveHistory,
@@ -292,6 +293,24 @@ export function findPreviousSailingsFromScrape(
 
   candidates.sort((a, b) => b.departMs - a.departMs);
   return candidates.slice(0, PREVIOUS_SAILING_LIMIT).map((c) => c.prev);
+}
+
+/**
+ * Eject stored rows whose scheduledDepart doesn't match any entry in the
+ * authoritative dailySchedule for their route. Runs alongside the schedule
+ * override pipeline so contaminated rows are removed before they can
+ * mis-match a subsequent upsertFromApi or contaminate the localStorage
+ * fallback path for previousSailings.
+ */
+export function persistContaminationEviction(
+  scheduledListByRoute: Map<string, Date[]> | undefined,
+): void {
+  if (typeof localStorage === 'undefined') return;
+  if (!scheduledListByRoute?.size) return;
+  const state = loadHistory();
+  if (state.sailings.length === 0) return;
+  const next = evictContaminatedRows(state, scheduledListByRoute);
+  if (next !== state) saveHistory(next);
 }
 
 /**

--- a/src/lib/client/schedule.ts
+++ b/src/lib/client/schedule.ts
@@ -1,4 +1,5 @@
-import type { DailySchedule } from 'scrapemyferry';
+import type { CurrentConditionsBeta, DailySchedule } from 'scrapemyferry';
+import { vessels } from '$lib/data/vessels';
 import { parseWallClockTime } from '$lib/utils';
 import {
   loadHistory,
@@ -6,9 +7,42 @@ import {
   saveHistory,
   type ScheduledDepartCorrection,
 } from './history';
-import type { Route, Sailing } from './types';
+import type { Route, Sailing, SailingStatus, Vessel } from './types';
 
 const MATCH_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Some BC Ferries API routes (often noncapacity ones) come back with an
+ * empty sailingDuration, so `route.duration` parses to 0. That breaks every
+ * downstream delay calc (depart/arrive over-under, total time from scheduled
+ * departure, progress bar). Fall back to the first parseable duration in
+ * scrapemyferry's dailySchedule for that route, which is always populated.
+ *
+ * Per-sailing duration variance (e.g. a "Round trip" entry that's longer
+ * than regular sailings) is ignored here — picking the first entry is a
+ * pragmatic choice that handles the typical case and avoids threading
+ * per-sailing duration through the render pipeline.
+ */
+export function applyDurationOverride(
+  route: Route | undefined,
+  dailySchedule: DailySchedule | null | undefined,
+): Route | undefined {
+  if (!route) return route;
+  if (route.duration > 0) return route;
+  if (!dailySchedule?.sailings?.length) return route;
+  for (const entry of dailySchedule.sailings) {
+    const seconds = parseScheduleDurationSeconds(entry.duration);
+    if (seconds > 0) return { ...route, duration: seconds };
+  }
+  return route;
+}
+
+// dailySchedule entries report duration as "HH:MM" (e.g. "00:40", "01:35").
+function parseScheduleDurationSeconds(value: string): number {
+  const match = /^(\d+):(\d+)$/.exec(value.trim());
+  if (!match) return 0;
+  return parseInt(match[1]) * 3600 + parseInt(match[2]) * 60;
+}
 
 export function buildScheduledList(dailySchedule: DailySchedule | null | undefined): Date[] {
   if (!dailySchedule?.sailings?.length) return [];
@@ -59,6 +93,99 @@ export function applyScheduleOverride(
   });
 
   return { ...route, sailings };
+}
+
+/**
+ * The BC Ferries JSON API only returns a windowed slice of today's sailings
+ * (typically a few past + a few upcoming), so the live sailings list is
+ * incomplete. Use scrapemyferry's full dailySchedule to fill in the gaps,
+ * enriching synthesized sailings with vessel + actual times from
+ * currentConditionsBeta when an entry there matches.
+ */
+export function injectMissingSailings(
+  route: Route | undefined,
+  dailySchedule: DailySchedule | null | undefined,
+  conditions: CurrentConditionsBeta | null | undefined,
+): Route | undefined {
+  if (!route) return route;
+  if (!dailySchedule?.sailings?.length) return route;
+
+  // Track scheduled times already represented in the live list so we don't
+  // duplicate. Live sailings carry scheduledDepart from applyScheduleOverride
+  // when a dailySchedule entry was claimed; otherwise their `depart` itself
+  // is the relevant marker.
+  const presentScheduledMs = new Set<number>();
+  for (const s of route.sailings) {
+    if (s.scheduledDepart instanceof Date) {
+      presentScheduledMs.add(s.scheduledDepart.getTime());
+    } else if (s.depart instanceof Date) {
+      presentScheduledMs.add(s.depart.getTime());
+    }
+  }
+
+  const arrivedByScheduled = new Map<string, CurrentConditionsBeta['arrivedUnderway'][number]>();
+  const upcomingByScheduled = new Map<string, CurrentConditionsBeta['upcoming'][number]>();
+  for (const a of conditions?.arrivedUnderway ?? []) arrivedByScheduled.set(a.scheduled, a);
+  for (const u of conditions?.upcoming ?? []) upcomingByScheduled.set(u.scheduled, u);
+
+  const nowMs = Date.now();
+  const injected: Sailing[] = [];
+
+  for (const entry of dailySchedule.sailings) {
+    const scheduled = parseWallClockTime(entry.depart);
+    if (!scheduled) continue;
+    if (presentScheduledMs.has(scheduled.getTime())) continue;
+
+    const arriveScheduled = parseWallClockTime(entry.arrive);
+    const arrivedEntry = arrivedByScheduled.get(entry.depart);
+    const upcomingEntry = upcomingByScheduled.get(entry.depart);
+
+    let depart: Date = scheduled;
+    let arrive: Date | undefined = arriveScheduled;
+    let vessel: Vessel | undefined;
+    let status: SailingStatus | undefined;
+
+    if (arrivedEntry) {
+      depart = parseWallClockTime(arrivedEntry.departed) ?? scheduled;
+      arrive = parseWallClockTime(arrivedEntry.arrived) ?? arriveScheduled;
+      vessel = makeVessel(arrivedEntry.vessel?.name);
+      status = 'past';
+    } else if (upcomingEntry) {
+      depart = parseWallClockTime(upcomingEntry.etd) ?? scheduled;
+      arrive = parseWallClockTime(upcomingEntry.eta) ?? arriveScheduled;
+      vessel = makeVessel(upcomingEntry.vessel?.name);
+      status = 'future';
+    } else {
+      // no conditions enrichment — infer status from scheduled times alone
+      if (scheduled.getTime() > nowMs) status = 'future';
+      else if (arriveScheduled && arriveScheduled.getTime() > nowMs) status = 'current';
+      else status = 'past';
+    }
+
+    injected.push({ depart, arrive, scheduledDepart: scheduled, vessel, status });
+  }
+
+  if (injected.length === 0) return route;
+
+  const sailings = [...route.sailings, ...injected].sort(sailingSortKey);
+  return { ...route, sailings };
+}
+
+function makeVessel(name: string | undefined): Vessel | undefined {
+  if (!name) return undefined;
+  return { ...vessels[name], name };
+}
+
+function sailingSortKey(a: Sailing, b: Sailing): number {
+  const aMs = sortMs(a);
+  const bMs = sortMs(b);
+  return aMs - bMs;
+}
+
+function sortMs(s: Sailing): number {
+  if (s.scheduledDepart instanceof Date) return s.scheduledDepart.getTime();
+  if (s.depart instanceof Date) return s.depart.getTime();
+  return Number.MAX_SAFE_INTEGER;
 }
 
 /**

--- a/src/lib/client/transform.ts
+++ b/src/lib/client/transform.ts
@@ -204,9 +204,7 @@ export function transformRoutes(routesData: RouteData[], timestampData: number):
 
         const [hours, minutes, period] = match.slice(1);
         const parsedDate = new Date();
-        parsedDate.setHours(
-          (parseInt(hours) % 12) + (period.toLowerCase() === 'pm' ? 12 : 0),
-        );
+        parsedDate.setHours((parseInt(hours) % 12) + (period.toLowerCase() === 'pm' ? 12 : 0));
         parsedDate.setMinutes(parseInt(minutes));
         parsedDate.setSeconds(0);
         parsedDate.setMilliseconds(0);

--- a/src/lib/components/terminal-context/terminal-context.svelte
+++ b/src/lib/components/terminal-context/terminal-context.svelte
@@ -32,10 +32,7 @@
     return { from: match[1], to: match[2] };
   }
 
-  function findFromName(
-    routes: Routes | null,
-    pair: { from: string; to: string } | undefined,
-  ) {
+  function findFromName(routes: Routes | null, pair: { from: string; to: string } | undefined) {
     if (!routes || !pair) return;
     for (const region of routes.regions) {
       for (const from of region.from) {

--- a/src/lib/components/terminal-sailings/terminal-sailing-item.svelte
+++ b/src/lib/components/terminal-sailings/terminal-sailing-item.svelte
@@ -99,7 +99,13 @@
     }
   }
 
-  function calcOverUnder({ depart, arrive }: Sailing, duration: number) {
+  function calcOverUnder({ depart, arrive, status }: Sailing, duration: number) {
+    // Skip future sailings: depart/arrive are forecasts (etd/eta or pure
+    // schedule), and any delta is either a forecast deviation or a phantom
+    // mismatch between route.duration and the per-sailing scheduled duration.
+    // Once the sailing is departing/current/past, the delta reflects observed
+    // reality and is worth showing.
+    if (status === 'future') return;
     if (!(depart instanceof Date) || !(arrive instanceof Date)) return;
 
     return (arrive.getTime() - depart.getTime()) / 1000 - duration;

--- a/src/lib/server/scrapemyferry.ts
+++ b/src/lib/server/scrapemyferry.ts
@@ -46,23 +46,37 @@ export async function loadStaticContext(slug?: string): Promise<StaticContext> {
 
   if (!pair) {
     const routes = await routesPromise;
-    return { routes, conditions: null, arrivalConditions: null, dailySchedule: null };
+    return {
+      routes,
+      conditions: null,
+      arrivalConditions: null,
+      dailySchedule: null,
+      reverseDailySchedule: null,
+    };
   }
 
   const { from, to } = pair;
-  const [routes, conditions, arrivalConditions, dailySchedule] = await Promise.all([
-    routesPromise,
-    cached(`conditions:${from}-${to}`, TTL_MS.conditions, () =>
-      source.currentConditionsBeta(from, to),
-    ),
-    // Second scrape for the reverse direction so we can show the arrival
-    // terminal's address. The conditions payload always carries info for the
-    // "from" terminal, so flipping the args is the only way to get the other.
-    cached(`conditions:${to}-${from}`, TTL_MS.conditions, () =>
-      source.currentConditionsBeta(to, from),
-    ),
-    cached(`daily:${from}-${to}`, TTL_MS.dailySchedule, () => source.dailySchedule(from, to)),
-  ]);
+  const [routes, conditions, arrivalConditions, dailySchedule, reverseDailySchedule] =
+    await Promise.all([
+      routesPromise,
+      cached(`conditions:${from}-${to}`, TTL_MS.conditions, () =>
+        source.currentConditionsBeta(from, to),
+      ),
+      // Second conditions scrape for the reverse direction so we can show the
+      // arrival terminal's address. The conditions payload always carries info
+      // for the "from" terminal, so flipping the args is the only way to get
+      // the other.
+      cached(`conditions:${to}-${from}`, TTL_MS.conditions, () =>
+        source.currentConditionsBeta(to, from),
+      ),
+      cached(`daily:${from}-${to}`, TTL_MS.dailySchedule, () => source.dailySchedule(from, to)),
+      // Reverse-leg dailySchedule lets us override scheduledDepart and
+      // duration for previousSailings on the reverse route (the same vessel's
+      // inbound trips). Without this, reverse-leg rows fall back to stored
+      // localStorage data which is often contaminated by the live API's
+      // windowed observation pattern.
+      cached(`daily:${to}-${from}`, TTL_MS.dailySchedule, () => source.dailySchedule(to, from)),
+    ]);
 
-  return { routes, conditions, arrivalConditions, dailySchedule };
+  return { routes, conditions, arrivalConditions, dailySchedule, reverseDailySchedule };
 }

--- a/src/lib/server/types.ts
+++ b/src/lib/server/types.ts
@@ -5,4 +5,5 @@ export type StaticContext = {
   conditions: CurrentConditionsBeta | null;
   arrivalConditions: CurrentConditionsBeta | null;
   dailySchedule: DailySchedule | null;
+  reverseDailySchedule: DailySchedule | null;
 };

--- a/src/routes/[[slug]]/+page.svelte
+++ b/src/routes/[[slug]]/+page.svelte
@@ -10,6 +10,7 @@
     buildScheduledList,
     injectMissingSailings,
     persistScheduleCorrections,
+    type PrevSailingScrapeSource,
   } from '$lib/client/schedule';
   import TerminalHeader from '$lib/components/terminal-header.svelte';
   import TerminalSailings from '$lib/components/terminal-sailings/terminal-sailings.svelte';
@@ -51,14 +52,20 @@
   // Routes map with duration overrides applied for both forward and reverse
   // legs, so prior-sailing lookups on either direction get correct duration.
   $: enrichedRoutes = buildEnrichedRoutes(liveData?.routes, liveRoute, data.reverseDailySchedule);
-  $: scheduledListByRoute = buildScheduledListByRoute(liveRoute, scheduledList, reverseScheduledList);
-  // injectMissingSailings runs after mergeWithHistory, so its synthesized
-  // sailings never got their previousSailings attached during polling. Re-run
-  // the attach pass over the full post-inject list so injected sailings show
-  // the same recent-vessel-history rows as live sailings do.
+  $: scheduledListByRoute = buildScheduledListByRoute(
+    liveRoute,
+    scheduledList,
+    reverseScheduledList,
+  );
+  // scrapemyferry's arrivedUnderway is the primary source for previousSailings.
+  // localStorage history (via attachPreviousSailingsToRoute) is the fallback
+  // for vessels whose recent activity isn't in the current page's conditions
+  // payloads (e.g. they served a totally different route).
+  $: scrapeSources = buildScrapeSources(liveRoute, enrichedRoutes, data);
   $: selectedRoute = attachPreviousSailingsToRoute(
     injectMissingSailings(liveRoute, data.dailySchedule, data.conditions),
     enrichedRoutes,
+    scrapeSources,
     scheduledListByRoute,
   );
   $: enrichment = buildEnrichmentMap(data.conditions?.upcoming);
@@ -105,6 +112,47 @@
     if (forward.length) map.set(route.id, forward);
     if (reverse.length) map.set(`${route.to}${route.from}`, reverse);
     return map.size > 0 ? map : undefined;
+  }
+
+  function buildScrapeSources(
+    route: ReturnType<typeof loadRouteFromSlug>,
+    routes: Map<string, ReturnType<typeof loadRouteFromSlug>> | undefined,
+    data: PageData,
+  ): PrevSailingScrapeSource[] | undefined {
+    if (!route) return;
+    const sources: PrevSailingScrapeSource[] = [];
+    sources.push({
+      routeCode: route.id,
+      from: route.from,
+      to: route.to,
+      duration: route.duration,
+      conditions: data.conditions,
+      dailySchedule: data.dailySchedule,
+    });
+    const reverseId = `${route.to}${route.from}`;
+    const reverse = routes?.get(reverseId);
+    if (reverse) {
+      sources.push({
+        routeCode: reverseId,
+        from: route.to,
+        to: route.from,
+        duration: reverse.duration,
+        conditions: data.arrivalConditions,
+        dailySchedule: data.reverseDailySchedule,
+      });
+    } else {
+      // No live route entry — synthesize one so reverse-leg prior sailings
+      // still flow through with route metadata from scrapemyferry.
+      sources.push({
+        routeCode: reverseId,
+        from: route.to,
+        to: route.from,
+        duration: 0,
+        conditions: data.arrivalConditions,
+        dailySchedule: data.reverseDailySchedule,
+      });
+    }
+    return sources;
   }
 
   function buildLinks(raw: CurrentConditionsBeta['links'] | undefined): SailingLinks | undefined {

--- a/src/routes/[[slug]]/+page.svelte
+++ b/src/routes/[[slug]]/+page.svelte
@@ -9,6 +9,7 @@
     buildEnrichedRoutes,
     buildScheduledList,
     injectMissingSailings,
+    persistContaminationEviction,
     persistScheduleCorrections,
     type PrevSailingScrapeSource,
   } from '$lib/client/schedule';
@@ -57,6 +58,11 @@
     scheduledList,
     reverseScheduledList,
   );
+  // Evict contaminated rows on routes we have authoritative schedules for.
+  // Cheap when nothing's contaminated; prevents bad rows from being matched
+  // against by the next poll tick or from leaking into the localStorage
+  // fallback path for previousSailings.
+  $: persistContaminationEviction(scheduledListByRoute);
   // scrapemyferry's arrivedUnderway is the primary source for previousSailings.
   // localStorage history (via attachPreviousSailingsToRoute) is the fallback
   // for vessels whose recent activity isn't in the current page's conditions

--- a/src/routes/[[slug]]/+page.svelte
+++ b/src/routes/[[slug]]/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { poll, type Data } from '$lib/client';
+  import { attachPreviousSailingsToRoute } from '$lib/client/history';
   import {
     applyDurationOverride,
     applyScheduleOverride,
@@ -43,7 +44,14 @@
     scheduledList,
   );
   $: persistScheduleCorrections(liveRoute);
-  $: selectedRoute = injectMissingSailings(liveRoute, data.dailySchedule, data.conditions);
+  // injectMissingSailings runs after mergeWithHistory, so its synthesized
+  // sailings never got their previousSailings attached during polling. Re-run
+  // the attach pass over the full post-inject list so injected sailings show
+  // the same recent-vessel-history rows as live sailings do.
+  $: selectedRoute = attachPreviousSailingsToRoute(
+    injectMissingSailings(liveRoute, data.dailySchedule, data.conditions),
+    liveData?.routes,
+  );
   $: enrichment = buildEnrichmentMap(data.conditions?.upcoming);
   $: links = buildLinks(data.conditions?.links);
 

--- a/src/routes/[[slug]]/+page.svelte
+++ b/src/routes/[[slug]]/+page.svelte
@@ -3,8 +3,10 @@
   import { page } from '$app/stores';
   import { poll, type Data } from '$lib/client';
   import {
+    applyDurationOverride,
     applyScheduleOverride,
     buildScheduledList,
+    injectMissingSailings,
     persistScheduleCorrections,
   } from '$lib/client/schedule';
   import TerminalHeader from '$lib/components/terminal-header.svelte';
@@ -30,11 +32,18 @@
   // scheduledDepart — recomputed once when SSR data refreshes, then applied
   // to every live update.
   $: scheduledList = buildScheduledList(data.dailySchedule);
-  $: selectedRoute = applyScheduleOverride(loadRouteFromSlug(liveData, slug), scheduledList);
-  // Reconcile localStorage with the corrected scheduledDepart so features
-  // that read directly from history (previousSailings) also benefit. Cheap
-  // when nothing changed (early-returns before touching localStorage).
-  $: persistScheduleCorrections(selectedRoute);
+  // Apply override against the slice the live API returned (this is what we
+  // want to reconcile back to localStorage). injectMissingSailings then fills
+  // in the rest of today from dailySchedule so the UI shows the full day.
+  // Duration override fills in route.duration for routes where the live API
+  // returns an empty sailingDuration — without it, downstream delay math
+  // produces phantom over-under values.
+  $: liveRoute = applyScheduleOverride(
+    applyDurationOverride(loadRouteFromSlug(liveData, slug), data.dailySchedule),
+    scheduledList,
+  );
+  $: persistScheduleCorrections(liveRoute);
+  $: selectedRoute = injectMissingSailings(liveRoute, data.dailySchedule, data.conditions);
   $: enrichment = buildEnrichmentMap(data.conditions?.upcoming);
   $: links = buildLinks(data.conditions?.links);
 

--- a/src/routes/[[slug]]/+page.svelte
+++ b/src/routes/[[slug]]/+page.svelte
@@ -6,6 +6,7 @@
   import {
     applyDurationOverride,
     applyScheduleOverride,
+    buildEnrichedRoutes,
     buildScheduledList,
     injectMissingSailings,
     persistScheduleCorrections,
@@ -31,8 +32,11 @@
   $: slug = $page.params.slug;
   // scrapemyferry's published dailySchedule is the authoritative source for
   // scheduledDepart — recomputed once when SSR data refreshes, then applied
-  // to every live update.
+  // to every live update. Both forward and reverse direction lists feed the
+  // previousSailings override so inbound prior trips (reverse route) get
+  // proper scheduledDepart instead of stale stored values.
   $: scheduledList = buildScheduledList(data.dailySchedule);
+  $: reverseScheduledList = buildScheduledList(data.reverseDailySchedule);
   // Apply override against the slice the live API returned (this is what we
   // want to reconcile back to localStorage). injectMissingSailings then fills
   // in the rest of today from dailySchedule so the UI shows the full day.
@@ -44,13 +48,18 @@
     scheduledList,
   );
   $: persistScheduleCorrections(liveRoute);
+  // Routes map with duration overrides applied for both forward and reverse
+  // legs, so prior-sailing lookups on either direction get correct duration.
+  $: enrichedRoutes = buildEnrichedRoutes(liveData?.routes, liveRoute, data.reverseDailySchedule);
+  $: scheduledListByRoute = buildScheduledListByRoute(liveRoute, scheduledList, reverseScheduledList);
   // injectMissingSailings runs after mergeWithHistory, so its synthesized
   // sailings never got their previousSailings attached during polling. Re-run
   // the attach pass over the full post-inject list so injected sailings show
   // the same recent-vessel-history rows as live sailings do.
   $: selectedRoute = attachPreviousSailingsToRoute(
     injectMissingSailings(liveRoute, data.dailySchedule, data.conditions),
-    liveData?.routes,
+    enrichedRoutes,
+    scheduledListByRoute,
   );
   $: enrichment = buildEnrichmentMap(data.conditions?.upcoming);
   $: links = buildLinks(data.conditions?.links);
@@ -84,6 +93,18 @@
       map.set(entry.scheduled, enrichment);
     }
     return map;
+  }
+
+  function buildScheduledListByRoute(
+    route: ReturnType<typeof loadRouteFromSlug>,
+    forward: Date[],
+    reverse: Date[],
+  ): Map<string, Date[]> | undefined {
+    if (!route) return;
+    const map = new Map<string, Date[]>();
+    if (forward.length) map.set(route.id, forward);
+    if (reverse.length) map.set(`${route.to}${route.from}`, reverse);
+    return map.size > 0 ? map : undefined;
   }
 
   function buildLinks(raw: CurrentConditionsBeta['links'] | undefined): SailingLinks | undefined {


### PR DESCRIPTION
## Summary
Follow-up fixes after the prior PR landed. The headline change is a fundamental rework of the data-authority model: **scrapemyferry is now the primary source for past/current sailings, localStorage is a fallback only**.

### Schedule completeness & accuracy
- **Inject missing sailings from `dailySchedule`** — the BC Ferries JSON API only returns a windowed slice (a few past + a few upcoming). Routes like HSB-NAN now render all 7 daily sailings, with past entries enriched by `currentConditionsBeta.arrivedUnderway` (vessel + actual times) and future entries by `currentConditionsBeta.upcoming` (vessel + etd/eta).
- **Duration override** — `route.duration` is 0 for some API responses. `applyDurationOverride` falls back to scrapemyferry's first parseable `HH:MM` entry, fixing every dependent calculation (over/under, total time, progress bar).
- **Reverse-leg dailySchedule** — server also fetches `dailySchedule(to, from)` so previousSailings on the reverse leg get authoritative `scheduledDepart` + `duration` (per-sailing, not a single route-wide value).

### previousSailings rework
- **`findPreviousSailingsFromScrape`** reads each direction's `arrivedUnderway` filtered by vessel + 6h window. Pairs each entry with its `dailySchedule.duration` for projected-arrive math when the vessel is still underway. This is the **primary** source.
- **`attachPreviousSailingsToRoute`** now prefers scrape data; localStorage history is consulted only when scrape returns nothing for a vessel (covers vessels that briefly served an out-of-page route).
- **`mergeWithHistory` no longer attaches previousSailings** — work fully owned by the page-level pipeline so it can prefer scrape.
- **Projected arrive for underway sailings** — when `arrivedUnderway.arrived` is missing or the vessel is still in transit, projects `arrive = depart + duration` so the row still renders and the delta means something.

### Data authority cleanup (localStorage hygiene)
- **`upsertFromApi` restricted to future sailings** — once a sailing is current/past, scrapemyferry has more accurate actuals. We no longer overwrite stored fields with API values that may be incomplete or contaminated; just bump `lastSeenAt` so the row survives pruning.
- **`evictContaminatedRows`** — drops rows whose `scheduledDepart` doesn't match any actual entry in the authoritative `dailySchedule` for their route (within 5 min). Closes the contamination feedback loop where `findMatch` could keep gluing new observations onto phantom rows.
- **Always-reload in `poll`** — `notify` now `loadHistory()` every tick instead of caching, so page-level writes (eviction, reconciliation) aren't clobbered by the next saveHistory.

### Bug fixes
- **No delta badge on future sailings** — `calcOverUnder` skips `status === 'future'`; the depart/arrive on a future sailing is forecast and any delta is speculative.
- **Prettier scripts** — dedicated `prettier:check` and `prettier:write` so prettier can run in isolation.

## Test plan
- [ ] `pnpm check` — types clean
- [ ] `/HSBNAN` renders all 7 daily sailings; past entries show actual vessel + arrival time, upcoming entries show vessel + etd/eta
- [ ] No `(+Nm)` or `(-Nm)` badge appears on the arrival side of any future sailing's trigger row; the "in Xm" ETA still renders
- [ ] previousSailings on the reverse leg (e.g. NAN-HSB rows under an HSB-NAN parent) show correct depart/arrive/scheduledDepart/duration, not the contaminated-stored values seen previously
- [ ] Underway previous sailings (no actual arrival yet) project arrive = depart + duration and render a meaningful delta
- [ ] Existing localStorage contamination is cleaned up on first load: stored rows whose `scheduledDepart` doesn't match `dailySchedule` are evicted
- [ ] localStorage isn't being written to from non-future sailings (verify in DevTools Application > Local Storage that `wmf:sailings:v1` only contains rows with `lastStatus: 'future'` once existing rows age out)
- [ ] `pnpm prettier:check` exits 0 on a clean tree; `pnpm prettier:write` is a no-op afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)